### PR TITLE
Use upstream structs where possible

### DIFF
--- a/http/state_version.go
+++ b/http/state_version.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"github.com/gorilla/mux"
+	"github.com/hashicorp/go-tfe"
 	"github.com/leg100/ots"
 )
 
@@ -41,8 +42,8 @@ func (h *Server) GetStateVersion(w http.ResponseWriter, r *http.Request) {
 func (h *Server) CreateStateVersion(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 
-	CreateObject(w, r, &ots.StateVersionCreateOptions{}, func(opts interface{}) (interface{}, error) {
-		return h.StateVersionService.CreateStateVersion(vars["workspace_id"], opts.(*ots.StateVersionCreateOptions))
+	CreateObject(w, r, &tfe.StateVersionCreateOptions{}, func(opts interface{}) (interface{}, error) {
+		return h.StateVersionService.CreateStateVersion(vars["workspace_id"], opts.(*tfe.StateVersionCreateOptions))
 	})
 }
 

--- a/http/workspace.go
+++ b/http/workspace.go
@@ -45,8 +45,8 @@ func (h *Server) GetWorkspaceByID(w http.ResponseWriter, r *http.Request) {
 func (h *Server) CreateWorkspace(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 
-	CreateObject(w, r, &ots.WorkspaceCreateOptions{}, func(opts interface{}) (interface{}, error) {
-		return h.WorkspaceService.CreateWorkspace(vars["org"], opts.(*ots.WorkspaceCreateOptions))
+	CreateObject(w, r, &tfe.WorkspaceCreateOptions{}, func(opts interface{}) (interface{}, error) {
+		return h.WorkspaceService.CreateWorkspace(vars["org"], opts.(*tfe.WorkspaceCreateOptions))
 	})
 }
 

--- a/http/workspace_test.go
+++ b/http/workspace_test.go
@@ -18,7 +18,7 @@ import (
 func TestWorkspace(t *testing.T) {
 	s := &Server{}
 	s.WorkspaceService = &mock.WorkspaceService{
-		CreateWorkspaceFn: func(org string, opts *ots.WorkspaceCreateOptions) (*ots.Workspace, error) {
+		CreateWorkspaceFn: func(org string, opts *tfe.WorkspaceCreateOptions) (*ots.Workspace, error) {
 			return mock.NewWorkspace(*opts.Name, "ws-123", org), nil
 		},
 		UpdateWorkspaceFn: func(name, org string, opts *tfe.WorkspaceUpdateOptions) (*ots.Workspace, error) {

--- a/mock/workspace.go
+++ b/mock/workspace.go
@@ -8,7 +8,7 @@ import (
 var _ ots.WorkspaceService = (*WorkspaceService)(nil)
 
 type WorkspaceService struct {
-	CreateWorkspaceFn     func(org string, opts *ots.WorkspaceCreateOptions) (*ots.Workspace, error)
+	CreateWorkspaceFn     func(org string, opts *tfe.WorkspaceCreateOptions) (*ots.Workspace, error)
 	UpdateWorkspaceFn     func(name, org string, opts *tfe.WorkspaceUpdateOptions) (*ots.Workspace, error)
 	UpdateWorkspaceByIDFn func(id string, opts *tfe.WorkspaceUpdateOptions) (*ots.Workspace, error)
 	GetWorkspaceFn        func(name, org string) (*ots.Workspace, error)
@@ -20,7 +20,7 @@ type WorkspaceService struct {
 	UnlockWorkspaceFn     func(id string) (*ots.Workspace, error)
 }
 
-func (s WorkspaceService) CreateWorkspace(org string, opts *ots.WorkspaceCreateOptions) (*ots.Workspace, error) {
+func (s WorkspaceService) CreateWorkspace(org string, opts *tfe.WorkspaceCreateOptions) (*ots.Workspace, error) {
 	return s.CreateWorkspaceFn(org, opts)
 }
 

--- a/sqlite/state_version.go
+++ b/sqlite/state_version.go
@@ -4,6 +4,7 @@ import (
 	"encoding/base64"
 	"fmt"
 
+	"github.com/hashicorp/go-tfe"
 	"github.com/leg100/ots"
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
@@ -38,8 +39,8 @@ func NewStateVersionService(db *gorm.DB) *StateVersionService {
 	}
 }
 
-func NewStateVersionFromModel(model *StateVersionModel) *ots.StateVersion {
-	return &ots.StateVersion{
+func NewStateVersionFromModel(model *StateVersionModel) *tfe.StateVersion {
+	return &tfe.StateVersion{
 		ID:          model.ExternalID,
 		Serial:      model.Serial,
 		DownloadURL: fmt.Sprintf("/state-versions/%s/download", model.ExternalID),
@@ -50,7 +51,7 @@ func (StateVersionModel) TableName() string {
 	return "state_versions"
 }
 
-func (s StateVersionService) CreateStateVersion(workspaceID string, opts *ots.StateVersionCreateOptions) (*ots.StateVersion, error) {
+func (s StateVersionService) CreateStateVersion(workspaceID string, opts *tfe.StateVersionCreateOptions) (*tfe.StateVersion, error) {
 	workspace, err := getWorkspaceByID(s.DB, workspaceID)
 	if err != nil {
 		return nil, err
@@ -91,7 +92,7 @@ func (s StateVersionService) ListStateVersions(orgName, workspaceName string, op
 		return nil, result.Error
 	}
 
-	var items []*ots.StateVersion
+	var items []*tfe.StateVersion
 	for _, m := range models {
 		items = append(items, NewStateVersionFromModel(&m))
 	}
@@ -102,7 +103,7 @@ func (s StateVersionService) ListStateVersions(orgName, workspaceName string, op
 	}, nil
 }
 
-func (s StateVersionService) GetStateVersion(id string) (*ots.StateVersion, error) {
+func (s StateVersionService) GetStateVersion(id string) (*tfe.StateVersion, error) {
 	var model StateVersionModel
 
 	if result := s.DB.Preload(clause.Associations).Where("external_id = ?", id).First(&model); result.Error != nil {
@@ -112,7 +113,7 @@ func (s StateVersionService) GetStateVersion(id string) (*ots.StateVersion, erro
 	return NewStateVersionFromModel(&model), nil
 }
 
-func (s StateVersionService) CurrentStateVersion(workspaceID string) (*ots.StateVersion, error) {
+func (s StateVersionService) CurrentStateVersion(workspaceID string) (*tfe.StateVersion, error) {
 	var model StateVersionModel
 
 	workspace, err := getWorkspaceByID(s.DB, workspaceID)

--- a/sqlite/state_version_output.go
+++ b/sqlite/state_version_output.go
@@ -1,6 +1,7 @@
 package sqlite
 
 import (
+	"github.com/hashicorp/go-tfe"
 	"github.com/leg100/ots"
 	"gorm.io/gorm"
 )
@@ -31,8 +32,8 @@ func NewStateVersionOutputService(db *gorm.DB) *StateVersionOutputService {
 	}
 }
 
-func NewStateVersionOutputFromModel(model *StateVersionOutputModel) *ots.StateVersionOutput {
-	return &ots.StateVersionOutput{
+func NewStateVersionOutputFromModel(model *StateVersionOutputModel) *tfe.StateVersionOutput {
+	return &tfe.StateVersionOutput{
 		ID:        model.ExternalID,
 		Name:      model.Name,
 		Sensitive: model.Sensitive,
@@ -45,7 +46,7 @@ func (StateVersionOutputModel) TableName() string {
 	return "state_version_outputs"
 }
 
-func (s StateVersionOutputService) GetStateVersionOutput(id string) (*ots.StateVersionOutput, error) {
+func (s StateVersionOutputService) GetStateVersionOutput(id string) (*tfe.StateVersionOutput, error) {
 	var model StateVersionOutputModel
 
 	if result := s.DB.Where("external_id = ?", id).First(&model); result.Error != nil {

--- a/sqlite/workspace.go
+++ b/sqlite/workspace.go
@@ -55,11 +55,7 @@ func (WorkspaceModel) TableName() string {
 	return "workspaces"
 }
 
-func (s WorkspaceService) CreateWorkspace(orgName string, opts *ots.WorkspaceCreateOptions) (*ots.Workspace, error) {
-	if err := opts.Validate(); err != nil {
-		return nil, err
-	}
-
+func (s WorkspaceService) CreateWorkspace(orgName string, opts *tfe.WorkspaceCreateOptions) (*ots.Workspace, error) {
 	org, err := getOrganizationByName(s.DB, orgName)
 	if err != nil {
 		return nil, err

--- a/sqlite/workspace_test.go
+++ b/sqlite/workspace_test.go
@@ -26,7 +26,7 @@ func TestWorkspace(t *testing.T) {
 	require.NoError(t, err)
 
 	for _, name := range []string{"dev", "staging", "prod"} {
-		ws, err := svc.CreateWorkspace("automatize", &ots.WorkspaceCreateOptions{
+		ws, err := svc.CreateWorkspace("automatize", &tfe.WorkspaceCreateOptions{
 			Name: ots.String(name),
 		})
 		require.NoError(t, err)
@@ -84,7 +84,7 @@ func TestWorkspace(t *testing.T) {
 
 	// Re-create
 
-	ws, err = svc.CreateWorkspace("automatize", &ots.WorkspaceCreateOptions{
+	ws, err = svc.CreateWorkspace("automatize", &tfe.WorkspaceCreateOptions{
 		Name: ots.String("dev"),
 	})
 	require.NoError(t, err)

--- a/state_version.go
+++ b/state_version.go
@@ -2,59 +2,15 @@ package ots
 
 import (
 	"fmt"
-	"time"
 
 	"github.com/hashicorp/go-tfe"
 )
 
-// StateVersion represents a Terraform Enterprise state version.
-type StateVersion struct {
-	ID           string    `jsonapi:"primary,state-versions"`
-	CreatedAt    time.Time `jsonapi:"attr,created-at,iso8601"`
-	DownloadURL  string    `jsonapi:"attr,hosted-state-download-url"`
-	Serial       int64     `jsonapi:"attr,serial"`
-	VCSCommitSHA string    `jsonapi:"attr,vcs-commit-sha"`
-	VCSCommitURL string    `jsonapi:"attr,vcs-commit-url"`
-
-	// Relations
-	// Run     *Run                  `jsonapi:"relation,run"`
-	Outputs []*tfe.StateVersionOutput `jsonapi:"relation,outputs"`
-}
-
-// StateVersionCreateOptions represents the options for creating a state
-// version.
-type StateVersionCreateOptions struct {
-	// Type is a public field utilized by JSON:API to
-	// set the resource type via the field tag.
-	// It is not a user-defined value and does not need to be set.
-	// https://jsonapi.org/format/#crud-creating
-	Type string `jsonapi:"primary,state-versions"`
-
-	// The lineage of the state.
-	Lineage *string `jsonapi:"attr,lineage,omitempty"`
-
-	// The MD5 hash of the state version.
-	MD5 *string `jsonapi:"attr,md5"`
-
-	// The serial of the state.
-	Serial *int64 `jsonapi:"attr,serial"`
-
-	// The base64 encoded state.
-	State *string `jsonapi:"attr,state"`
-
-	// Force can be set to skip certain validations. Wrong use
-	// of this flag can cause data loss, so USE WITH CAUTION!
-	Force *bool `jsonapi:"attr,force"`
-
-	// Specifies the run to associate the state with.
-	// Run *Run `jsonapi:"relation,run,omitempty"`
-}
-
 type StateVersionService interface {
-	CreateStateVersion(workspaceID string, opts *StateVersionCreateOptions) (*StateVersion, error)
+	CreateStateVersion(workspaceID string, opts *tfe.StateVersionCreateOptions) (*tfe.StateVersion, error)
 	ListStateVersions(orgName, workspaceName string, opts StateVersionListOptions) (*StateVersionList, error)
-	CurrentStateVersion(workspaceID string) (*StateVersion, error)
-	GetStateVersion(id string) (*StateVersion, error)
+	CurrentStateVersion(workspaceID string) (*tfe.StateVersion, error)
+	GetStateVersion(id string) (*tfe.StateVersion, error)
 	DownloadStateVersion(id string) ([]byte, error)
 }
 

--- a/state_version_list.go
+++ b/state_version_list.go
@@ -1,8 +1,10 @@
 package ots
 
+import tfe "github.com/hashicorp/go-tfe"
+
 type StateVersionList struct {
 	*Pagination
-	Items []*StateVersion
+	Items []*tfe.StateVersion
 }
 
 // StateVersionListOptions represents the options for listing state versions.

--- a/state_version_output.go
+++ b/state_version_output.go
@@ -3,25 +3,11 @@ package ots
 import (
 	"fmt"
 
-	"github.com/google/jsonapi"
+	"github.com/hashicorp/go-tfe"
 )
 
-type StateVersionOutput struct {
-	ID        string `jsonapi:"primary,state-version-outputs"`
-	Name      string `jsonapi:"attr,name"`
-	Sensitive bool   `jsonapi:"attr,sensitive"`
-	Type      string `jsonapi:"attr,type"`
-	Value     string `jsonapi:"attr,value"`
-}
-
 type StateVersionOutputService interface {
-	GetStateVersionOutput(id string) (*StateVersionOutput, error)
-}
-
-func (svo *StateVersionOutput) JSONAPILinks() *jsonapi.Links {
-	return &jsonapi.Links{
-		"self": fmt.Sprintf("/api/v2/state-version-outputs/%s", svo.ID),
-	}
+	GetStateVersionOutput(id string) (*tfe.StateVersionOutput, error)
 }
 
 func NewStateVersionOutputID() string {


### PR DESCRIPTION
It's better to use the structs from the hashicorp maintained go-tfe repo. We can then leverage ongoing updates to those structs which likely (?) reflect changes in the terraform bin.