### PR TITLE
Return conflict error when already locked/unlocked

### DIFF
--- a/http/helpers.go
+++ b/http/helpers.go
@@ -2,6 +2,7 @@ package http
 
 import (
 	"net/http"
+	"strconv"
 
 	"github.com/google/jsonapi"
 	"github.com/leg100/ots"
@@ -116,6 +117,17 @@ func ErrNotFound(w http.ResponseWriter, opts ...ErrOption) {
 	w.WriteHeader(http.StatusNotFound)
 	jsonapi.MarshalErrors(w, []*jsonapi.ErrorObject{
 		err,
+	})
+}
+
+func WriteError(w http.ResponseWriter, code int) {
+	w.Header().Set("Content-type", jsonapi.MediaType)
+
+	w.WriteHeader(code)
+	jsonapi.MarshalErrors(w, []*jsonapi.ErrorObject{
+		{
+			Status: strconv.Itoa(code),
+		},
 	})
 }
 

--- a/http/workspace.go
+++ b/http/workspace.go
@@ -98,8 +98,11 @@ func (h *Server) LockWorkspace(w http.ResponseWriter, r *http.Request) {
 	}
 
 	obj, err := h.WorkspaceService.LockWorkspace(vars["id"], opts)
-	if err != nil {
-		ErrNotFound(w)
+	if err == ots.ErrWorkspaceAlreadyLocked {
+		WriteError(w, http.StatusConflict)
+		return
+	} else if err != nil {
+		WriteError(w, http.StatusNotFound)
 		return
 	}
 
@@ -114,8 +117,11 @@ func (h *Server) UnlockWorkspace(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 
 	obj, err := h.WorkspaceService.UnlockWorkspace(vars["id"])
-	if err != nil {
-		ErrNotFound(w)
+	if err == ots.ErrWorkspaceAlreadyUnlocked {
+		WriteError(w, http.StatusConflict)
+		return
+	} else if err != nil {
+		WriteError(w, http.StatusNotFound)
 		return
 	}
 


### PR DESCRIPTION
Return a 409 Conflict when workspace is already locked/unlocked.