### PR TITLE
Log via logr interface

### DIFF
--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/go-logr/logr"
 	"github.com/leg100/go-tfe"
 	"github.com/leg100/ots"
 	"github.com/leg100/ots/mock"
@@ -30,6 +31,7 @@ func TestAgentPoller(t *testing.T) {
 	}
 
 	agent := &Agent{
+		Logger:                      logr.Discard(),
 		ConfigurationVersionService: &mock.ConfigurationVersionService{},
 		StateVersionService:         &mock.StateVersionService{},
 		PlanService:                 &mock.PlanService{},
@@ -77,6 +79,7 @@ func TestAgentPollerError(t *testing.T) {
 	}
 
 	agent := &Agent{
+		Logger:                      logr.Discard(),
 		ConfigurationVersionService: &mock.ConfigurationVersionService{},
 		StateVersionService:         &mock.StateVersionService{},
 		PlanService:                 &mock.PlanService{},

--- a/agent/processor.go
+++ b/agent/processor.go
@@ -9,9 +9,9 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/go-logr/logr"
 	"github.com/leg100/go-tfe"
 	"github.com/leg100/ots"
-	"github.com/rs/zerolog"
 )
 
 const (
@@ -27,7 +27,7 @@ type Processor interface {
 type processor struct {
 	Run *ots.Run
 
-	zerolog.Logger
+	logr.Logger
 
 	TerraformRunner TerraformRunner
 
@@ -91,12 +91,10 @@ func (p *processor) Plan(ctx context.Context, run *ots.Run, path string) error {
 		return fmt.Errorf("unable to finish plan: %w", err)
 	}
 
-	p.Info().
-		Str("run", run.ID).
-		Int("additions", info.adds).
-		Int("changes", info.changes).
-		Int("deletions", info.deletions).
-		Msg("job completed")
+	p.Info("job completed", "run", run.ID,
+		"additions", info.adds,
+		"changes", info.changes,
+		"deletions", info.deletions)
 
 	return nil
 }
@@ -163,12 +161,10 @@ func (p *processor) Apply(ctx context.Context, run *ots.Run, path string) error 
 		return fmt.Errorf("unable to finish apply: %w", err)
 	}
 
-	p.Info().
-		Str("run", run.ID).
-		Int("additions", info.adds).
-		Int("changes", info.changes).
-		Int("deletions", info.deletions).
-		Msg("job completed")
+	p.Info("job completed", "run", run.ID,
+		"additions", info.adds,
+		"changes", info.changes,
+		"deletions", info.deletions)
 
 	return nil
 }

--- a/agent/processor_test.go
+++ b/agent/processor_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/go-logr/logr"
 	"github.com/leg100/go-tfe"
 	"github.com/leg100/ots"
 	"github.com/leg100/ots/mock"
@@ -43,6 +44,7 @@ func TestProcessor(t *testing.T) {
 	path := t.TempDir()
 
 	p := &processor{
+		Logger: logr.Discard(),
 		ConfigurationVersionService: &mock.ConfigurationVersionService{
 			DownloadFn: func(id string) ([]byte, error) {
 				return os.ReadFile("testdata/unpack.tar.gz")

--- a/cmd/otsd/main.go
+++ b/cmd/otsd/main.go
@@ -6,13 +6,13 @@ import (
 	"os"
 	"time"
 
-	"github.com/butonic/zerologr"
 	"github.com/leg100/ots/agent"
 	"github.com/leg100/ots/app"
 	cmdutil "github.com/leg100/ots/cmd"
 	"github.com/leg100/ots/filestore"
 	"github.com/leg100/ots/http"
 	"github.com/leg100/ots/sqlite"
+	"github.com/leg100/zerologr"
 	"github.com/mitchellh/go-homedir"
 	"github.com/rs/zerolog"
 	"github.com/spf13/cobra"
@@ -68,7 +68,7 @@ func main() {
 
 	// Setup logger
 	zerologger := newLogger()
-	logger := zerologr.NewWithOptions(zerologr.Options{Logger: zerologger})
+	logger := zerologr.NewLogger(zerologger)
 	server.Logger = logger
 
 	// Validate SSL params

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,8 @@ module github.com/leg100/ots
 go 1.16
 
 require (
+	github.com/butonic/zerologr v0.0.0-20191210074216-d798ee237d84
+	github.com/go-logr/logr v0.1.0
 	github.com/google/uuid v1.3.0
 	github.com/gorilla/mux v1.8.0
 	github.com/gorilla/schema v1.2.0

--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,7 @@ module github.com/leg100/ots
 go 1.16
 
 require (
-	github.com/butonic/zerologr v0.0.0-20191210074216-d798ee237d84
-	github.com/go-logr/logr v0.1.0
+	github.com/go-logr/logr v1.0.0
 	github.com/google/uuid v1.3.0
 	github.com/gorilla/mux v1.8.0
 	github.com/gorilla/schema v1.2.0
@@ -12,6 +11,7 @@ require (
 	github.com/leg100/go-tfe v0.17.1-0.20210804135856-d05f7109100e
 	github.com/leg100/gorm-zerolog v0.1.1-0.20210718123649-2348997004e6
 	github.com/leg100/jsonapi v1.0.1-0.20210703183827-d0513d61dc3f
+	github.com/leg100/zerologr v0.0.0-20210805173127-2e0b118333c5
 	github.com/mattn/go-sqlite3 v1.14.7 // indirect
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/rs/zerolog v1.23.0

--- a/go.sum
+++ b/go.sum
@@ -30,8 +30,6 @@ github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/bketelsen/crypt v0.0.3-0.20200106085610-5cbc8cc4026c/go.mod h1:MKsuJmJgSg28kpZDP6UIiPt0e0Oz0kqKNGyRaWEPv84=
-github.com/butonic/zerologr v0.0.0-20191210074216-d798ee237d84 h1:QtNZstjgtfA6J7MwnpJhnDDEQoLWik468l4GttjrRkk=
-github.com/butonic/zerologr v0.0.0-20191210074216-d798ee237d84/go.mod h1:Jw3eYm4TLfPMNKzimBDxXceOJhFF7Oix/zd2PTK3UrM=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
@@ -53,8 +51,8 @@ github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
-github.com/go-logr/logr v0.1.0 h1:M1Tv3VzNlEHg6uyACnRdtrploV2P7wZqH8BoQMtz0cg=
-github.com/go-logr/logr v0.1.0/go.mod h1:ixOQHD9gLJUVQQ2ZOR7zLEifBX6tGkNJF4QyIY7sIas=
+github.com/go-logr/logr v1.0.0 h1:kH951GinvFVaQgy/ki/B3YYmQtRpExGigSJg6O8z5jo=
+github.com/go-logr/logr v1.0.0/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/go-test/deep v1.0.3 h1:ZrJSEWsXzPOxaZnFteGEfooLba+ju3FYIbOrS+rQd68=
 github.com/go-test/deep v1.0.3/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
@@ -154,6 +152,8 @@ github.com/leg100/gorm-zerolog v0.1.1-0.20210718123649-2348997004e6/go.mod h1:IV
 github.com/leg100/jsonapi v1.0.1-0.20210702195956-33ced97bb77e/go.mod h1:bxfK4GybcsXRZYxs4FWVlOe3vK5MN3midIRDqJxVoH0=
 github.com/leg100/jsonapi v1.0.1-0.20210703183827-d0513d61dc3f h1:B6cjxBElIm1uvJj0go33EfQnkW0mvmVaHVVsXn81od8=
 github.com/leg100/jsonapi v1.0.1-0.20210703183827-d0513d61dc3f/go.mod h1:bxfK4GybcsXRZYxs4FWVlOe3vK5MN3midIRDqJxVoH0=
+github.com/leg100/zerologr v0.0.0-20210805173127-2e0b118333c5 h1:i08aLIx3Mpb9BRm6GjetLVkLQnp8nE5dcoZWjtk8BlU=
+github.com/leg100/zerologr v0.0.0-20210805173127-2e0b118333c5/go.mod h1:vI53dtVFNGGmrWWiUmm9CsqxbMFO/hIG4MrM7AiY1Qs=
 github.com/magiconair/properties v1.8.1/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-isatty v0.0.3/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
@@ -198,7 +198,6 @@ github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40T
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rs/xid v1.2.1/go.mod h1:+uKXf+4Djp6Md1KODXJxgGQPKngRmWyn10oCKFzNHOQ=
-github.com/rs/zerolog v1.17.2/go.mod h1:9nvC1axdVrAHcu/s9taAVfBuIdTZLVQmKQyvrUjF5+I=
 github.com/rs/zerolog v1.20.0/go.mod h1:IzD0RJ65iWH0w97OQQebJEvTZYvsCUm9WVLWBQrJRjo=
 github.com/rs/zerolog v1.23.0 h1:UskrK+saS9P9Y789yNNulYKdARjPZuS35B8gJF2x60g=
 github.com/rs/zerolog v1.23.0/go.mod h1:6c7hFfxPOy7TacJc4Fcdi24/J0NKYGzjG8FWRI916Qo=
@@ -241,7 +240,6 @@ github.com/zclconf/go-cty v1.2.0/go.mod h1:hOPWgoHbaTUnI5k4D2ld+GRpFJSCe6bCM7m1q
 github.com/zclconf/go-cty v1.8.0 h1:s4AvqaeQzJIu3ndv4gVIhplVD0krU+bgrcLSVUnaWuA=
 github.com/zclconf/go-cty v1.8.0/go.mod h1:vVKLxnk3puL4qRAv72AO+W99LUD4da90g3uUAzyuvAk=
 github.com/zclconf/go-cty-debug v0.0.0-20191215020915-b22d67c1ba0b/go.mod h1:ZRKQfBXbGkpdV6QMzT3rU1kSTAnfu1dO8dPKjYprgj8=
-github.com/zenazn/goji v0.9.0/go.mod h1:7S9M489iMyHBNxwZnk9/EHS098H4/F6TATF2mIxtB1Q=
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=

--- a/go.sum
+++ b/go.sum
@@ -30,6 +30,8 @@ github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/bketelsen/crypt v0.0.3-0.20200106085610-5cbc8cc4026c/go.mod h1:MKsuJmJgSg28kpZDP6UIiPt0e0Oz0kqKNGyRaWEPv84=
+github.com/butonic/zerologr v0.0.0-20191210074216-d798ee237d84 h1:QtNZstjgtfA6J7MwnpJhnDDEQoLWik468l4GttjrRkk=
+github.com/butonic/zerologr v0.0.0-20191210074216-d798ee237d84/go.mod h1:Jw3eYm4TLfPMNKzimBDxXceOJhFF7Oix/zd2PTK3UrM=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
@@ -51,6 +53,8 @@ github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
+github.com/go-logr/logr v0.1.0 h1:M1Tv3VzNlEHg6uyACnRdtrploV2P7wZqH8BoQMtz0cg=
+github.com/go-logr/logr v0.1.0/go.mod h1:ixOQHD9gLJUVQQ2ZOR7zLEifBX6tGkNJF4QyIY7sIas=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/go-test/deep v1.0.3 h1:ZrJSEWsXzPOxaZnFteGEfooLba+ju3FYIbOrS+rQd68=
 github.com/go-test/deep v1.0.3/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
@@ -194,6 +198,7 @@ github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40T
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rs/xid v1.2.1/go.mod h1:+uKXf+4Djp6Md1KODXJxgGQPKngRmWyn10oCKFzNHOQ=
+github.com/rs/zerolog v1.17.2/go.mod h1:9nvC1axdVrAHcu/s9taAVfBuIdTZLVQmKQyvrUjF5+I=
 github.com/rs/zerolog v1.20.0/go.mod h1:IzD0RJ65iWH0w97OQQebJEvTZYvsCUm9WVLWBQrJRjo=
 github.com/rs/zerolog v1.23.0 h1:UskrK+saS9P9Y789yNNulYKdARjPZuS35B8gJF2x60g=
 github.com/rs/zerolog v1.23.0/go.mod h1:6c7hFfxPOy7TacJc4Fcdi24/J0NKYGzjG8FWRI916Qo=
@@ -236,6 +241,7 @@ github.com/zclconf/go-cty v1.2.0/go.mod h1:hOPWgoHbaTUnI5k4D2ld+GRpFJSCe6bCM7m1q
 github.com/zclconf/go-cty v1.8.0 h1:s4AvqaeQzJIu3ndv4gVIhplVD0krU+bgrcLSVUnaWuA=
 github.com/zclconf/go-cty v1.8.0/go.mod h1:vVKLxnk3puL4qRAv72AO+W99LUD4da90g3uUAzyuvAk=
 github.com/zclconf/go-cty-debug v0.0.0-20191215020915-b22d67c1ba0b/go.mod h1:ZRKQfBXbGkpdV6QMzT3rU1kSTAnfu1dO8dPKjYprgj8=
+github.com/zenazn/goji v0.9.0/go.mod h1:7S9M489iMyHBNxwZnk9/EHS098H4/F6TATF2mIxtB1Q=
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=

--- a/http/org_test.go
+++ b/http/org_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/go-logr/logr"
 	"github.com/leg100/go-tfe"
 	"github.com/leg100/jsonapi"
 	"github.com/leg100/ots"
@@ -16,7 +17,9 @@ import (
 )
 
 func TestOrganization(t *testing.T) {
-	s := &Server{}
+	s := &Server{
+		Logger: logr.Discard(),
+	}
 	s.OrganizationService = &mock.OrganizationService{
 		CreateOrganizationFn: func(opts *tfe.OrganizationCreateOptions) (*ots.Organization, error) {
 			return mock.NewOrganization(*opts.Name, *opts.Email), nil

--- a/http/server.go
+++ b/http/server.go
@@ -8,10 +8,10 @@ import (
 	"net/url"
 	"time"
 
+	"github.com/go-logr/logr"
 	"github.com/gorilla/mux"
 	"github.com/leg100/jsonapi"
 	"github.com/leg100/ots"
-	"github.com/rs/zerolog"
 	"github.com/urfave/negroni"
 )
 
@@ -36,7 +36,7 @@ type Server struct {
 	ln     net.Listener
 	err    chan error
 
-	zerolog.Logger
+	logr.Logger
 
 	SSL               bool
 	CertFile, KeyFile string
@@ -151,12 +151,11 @@ func NewRouter(server *Server) *negroni.Negroni {
 		next(rw, r)
 
 		res := rw.(negroni.ResponseWriter)
-		server.Info().
-			Dur("duration", time.Since(start)).
-			Int("status", res.Status()).
-			Str("method", r.Method).
-			Str("path", fmt.Sprintf("%s?%s", r.URL.Path, r.URL.RawQuery)).
-			Msg("request")
+		server.Info("request",
+			"duration", time.Since(start),
+			"status", res.Status(),
+			"method", r.Method,
+			"path", fmt.Sprintf("%s?%s", r.URL.Path, r.URL.RawQuery))
 	})
 
 	n.UseHandler(router)

--- a/http/workspace_test.go
+++ b/http/workspace_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/go-logr/logr"
 	"github.com/leg100/go-tfe"
 	"github.com/leg100/jsonapi"
 	"github.com/leg100/ots"
@@ -16,7 +17,9 @@ import (
 )
 
 func TestWorkspace(t *testing.T) {
-	s := &Server{}
+	s := &Server{
+		Logger: logr.Discard(),
+	}
 	s.WorkspaceService = &mock.WorkspaceService{
 		CreateWorkspaceFn: func(org string, opts *tfe.WorkspaceCreateOptions) (*ots.Workspace, error) {
 			return mock.NewWorkspace(*opts.Name, "ws-123", org), nil

--- a/sqlite/configuration_version_test.go
+++ b/sqlite/configuration_version_test.go
@@ -6,11 +6,10 @@ import (
 	"github.com/leg100/go-tfe"
 	"github.com/leg100/ots"
 	"github.com/stretchr/testify/require"
-	"gorm.io/gorm"
 )
 
 func TestConfigurationVersion(t *testing.T) {
-	db, err := New(":memory:", &gorm.Config{})
+	db, err := New(":memory:")
 	require.NoError(t, err)
 
 	cvDB := NewConfigurationVersionDB(db)

--- a/sqlite/org_test.go
+++ b/sqlite/org_test.go
@@ -6,11 +6,10 @@ import (
 	"github.com/leg100/go-tfe"
 	"github.com/leg100/ots"
 	"github.com/stretchr/testify/require"
-	"gorm.io/gorm"
 )
 
 func TestOrganization(t *testing.T) {
-	db, err := New(":memory:", &gorm.Config{})
+	db, err := New(":memory:")
 	require.NoError(t, err)
 
 	svc := NewOrganizationDB(db)

--- a/sqlite/sqlite.go
+++ b/sqlite/sqlite.go
@@ -2,7 +2,9 @@ package sqlite
 
 import (
 	"github.com/leg100/go-tfe"
+	gormzerolog "github.com/leg100/gorm-zerolog"
 	"github.com/leg100/ots"
+	"github.com/rs/zerolog"
 	driver "gorm.io/driver/sqlite"
 	"gorm.io/gorm"
 )
@@ -18,7 +20,20 @@ var models = []interface{}{
 	&Workspace{},
 }
 
-func New(path string, cfg *gorm.Config) (*gorm.DB, error) {
+type Option func(*gorm.Config)
+
+func WithZeroLogger(logger *zerolog.Logger) Option {
+	return func(cfg *gorm.Config) {
+		cfg.Logger = &gormzerolog.Logger{Zlog: *logger}
+	}
+}
+
+func New(path string, opts ...Option) (*gorm.DB, error) {
+	cfg := &gorm.Config{}
+	for _, o := range opts {
+		o(cfg)
+	}
+
 	db, err := gorm.Open(driver.Open(path), cfg)
 	if err != nil {
 		return nil, err

--- a/sqlite/state_version_test.go
+++ b/sqlite/state_version_test.go
@@ -1,17 +1,15 @@
 package sqlite
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/leg100/go-tfe"
 	"github.com/leg100/ots"
 	"github.com/stretchr/testify/require"
-	"gorm.io/gorm"
 )
 
 func TestStateVersion(t *testing.T) {
-	db, err := New(":memory:", &gorm.Config{})
+	db, err := New(":memory:")
 	require.NoError(t, err)
 
 	orgDB := NewOrganizationDB(db)

--- a/sqlite/workspace_test.go
+++ b/sqlite/workspace_test.go
@@ -1,17 +1,15 @@
 package sqlite
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/leg100/go-tfe"
 	"github.com/leg100/ots"
 	"github.com/stretchr/testify/require"
-	"gorm.io/gorm"
 )
 
 func TestWorkspace(t *testing.T) {
-	db, err := New(":memory:", &gorm.Config{})
+	db, err := New(":memory:")
 	require.NoError(t, err)
 
 	orgDB := NewOrganizationDB(db)


### PR DESCRIPTION
Log messages via the [logr](https://github.com/go-logr/logr) interface.

And adds a `--log-level` CLI flag.